### PR TITLE
Make library database publicly readable

### DIFF
--- a/modules/bootstrap/scripts/002-create-library-database.ts
+++ b/modules/bootstrap/scripts/002-create-library-database.ts
@@ -16,6 +16,35 @@ export class CreateLibraryDatabase extends Migration {
 
   async migrate(): Promise<void> {
     await this.server.db.create(this.dbName)
+
+    // Make database publicly readable
+    await this.server.request({
+      db: this.dbName,
+      method: 'PUT',
+      doc: '_security',
+      body: {
+        admins:  { names: [], roles: [ "_admin" ] },
+        members: { names: [], roles: [ ] },
+      }
+    })
+
+    // Make database only writable by users with the contentManager
+    // role or the _admin role
+    await this.server.request({
+      db: this.dbName,
+      method: 'PUT',
+      doc: '_design/permissions',
+      body: {
+        // @ts-ignore
+        validate_doc_update: function(newDoc, oldDoc, userCtx, secObj) {
+          const isContentManager = userCtx.roles.indexOf('contentManager') !== -1
+          const isAdmin          = userCtx.roles.indexOf('_admin') !== -1
+          if (!isContentManager && !isAdmin) {
+            throw ({ forbidden: 'You are not a content manager.' })
+          }
+        }.toString()
+      }
+    })
   }
 
   async revert(): Promise<void> {


### PR DESCRIPTION
Update migration script to:
- make library database publicly readable/writable
- check if user have enough permissions to write new documents